### PR TITLE
HTTPServer updates, header messages, cookies, routing parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .import
+test.gd
+logs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .import
-test.gd
 logs/

--- a/addons/godottpd/http_file_router.gd
+++ b/addons/godottpd/http_file_router.gd
@@ -1,0 +1,159 @@
+# Class inheriting HttpRouter for handling file serving requests
+extends HttpRouter
+class_name HttpFileRouter
+
+# Full path to the folder which will be exposed to web
+var path: String = ""
+
+# Full path to the fallback page which will be served if the requested file was not found
+var fallback_page: String = ""
+
+# An ordered list of extensions that will be checked 
+# if no file extension is provided by the request
+var extensions: PoolStringArray = ["html"]
+
+# A list of extensions that will be excluded if requested
+var exclude_extensions: PoolStringArray = []
+
+# Creates an HttpFileRouter intance
+#
+# #### Parameters
+# - path: Full path to the folder which will be exposed to web
+# - options: Optional Dictionary of options which can be configured.
+# 	- fallback_page: Full path to the fallback page which will be served if the requested file was not found
+#	- extensions: A list of extensions that will be checked if no file extension is provided by the request
+# 	- exclude_extensions: A list of extensions that will be excluded if requested
+func _init(
+	path: String, 
+	options: Dictionary = { 
+		fallback_page = fallback_page, 
+		extensions = extensions, 
+		exclude_extensions = exclude_extensions
+	}
+	) -> void:
+	self.path = path
+	self.fallback_page = options.get("fallback_page", "")
+	self.extensions = options.get("extensions", [])
+	self.exclude_extensions = options.get("exclude_extensions", [])
+
+# Handle a GET request
+func handle_get(request: HttpRequest, response: HttpResponse) -> void:
+	var serving_path: String = path + request.path
+	var file_exists: bool = _file_exists(serving_path)
+
+	if request.path.get_extension() == "" and not file_exists:
+		for extension in extensions:
+			serving_path = path + request.path + "." + extension
+			file_exists = _file_exists(serving_path)
+			if file_exists: 
+				break
+
+	# GDScript must be excluded, unless it is used as a preprocessor (php-like)
+	if (file_exists and not serving_path.get_extension() in ["gd"] + Array(exclude_extensions)):
+		response.send_raw(
+			200, 
+			_serve_file(serving_path), 
+			_get_mime(serving_path.get_extension())
+			)
+	else:
+		if fallback_page != "":
+			response.send_raw(404, _serve_file(fallback_page), _get_mime(fallback_page.get_extension()))
+		else:
+			response.send_raw(404)
+
+# (Internal function)
+# Reads a file as text
+#
+# #### Parameters
+# - file_path: Full path to the file
+func _serve_file(file_path: String) -> PoolByteArray:
+	var content: PoolByteArray = []
+	var file = File.new()
+	var file_opened: bool = not bool(file.open(file_path, File.READ))
+	if file_opened:
+		content = file.get_buffer(file.get_len())
+		file.close()
+	return content
+
+# (Internal Function)
+# Check if a file exists
+#
+# #### Parameters
+# - file_path: Full path to the file
+func _file_exists(file_path: String) -> bool:
+	return File.new().file_exists(file_path)
+
+# (Internal function)
+# Get the full MIME type of a file from its extension
+#
+# #### Parameters
+# - file_extension: Extension of the file to be served
+func _get_mime(file_extension: String) -> String:
+	var type: String = "application"
+	var subtype : String = "octet-stream"
+	match file_extension:
+		# Web files
+		"css","html","csv","js","mjs":
+			type = "text"
+			subtype = "javascript" if file_extension in ["js","mjs"] else file_extension 
+		"php":
+			subtype = "x-httpd-php"
+		"ttf","woff","woff2":
+			type = "font"
+			subtype = file_extension
+		# Image
+		"png","bmp","gif","png","webp":
+			type = "image"
+			subtype = file_extension
+		"jpeg","jpg":
+			type = "image"
+			subtype = "jpg"
+		"tiff", "tif":
+			type = "image"
+			subtype = "jpg"
+		"svg":
+			type = "image"
+			subtype = "svg+xml"
+		"ico":
+			type = "image"
+			subtype = "vnd.microsoft.icon"
+		# Documents
+		"doc":
+			subtype = "msword"
+		"docx":
+			subtype = "vnd.openxmlformats-officedocument.wordprocessingml.document"
+		"7z":
+			subtype = "x-7x-compressed"
+		"gz":
+			subtype = "gzip"
+		"tar":
+			subtype = "application/x-tar"
+		"json","pdf","zip":
+			subtype = file_extension
+		"txt":
+			type = "text"
+			subtype = "plain"
+		"ppt":
+			subtype = "vnd.ms-powerpoint"
+		# Audio
+		"midi","mp3","wav":
+			type = "audio"
+			subtype = file_extension
+		"mp4","mpeg","webm":
+			type = "audio"
+			subtype = file_extension
+		"oga","ogg":
+			type = "audio"
+			subtype = "ogg"
+		"mpkg":
+			subtype = "vnd.apple.installer+xml"
+		# Video
+		"ogv":
+			type = "video"
+			subtype = "ogg"
+		"avi":
+			type = "video"
+			subtype = "x-msvideo"
+		"ogx":
+			subtype = "ogg"
+	return type + "/" + subtype

--- a/addons/godottpd/http_request.gd
+++ b/addons/godottpd/http_request.gd
@@ -21,6 +21,8 @@ var method: String
 # A dictionary of request (aka. routing) parameters
 var parameters: Dictionary
 
+# A dictionary of request query parameters
+var query: Dictionary
 
 # Override `str()` method, automatically called in `print()` function
 func _to_string() -> String:

--- a/addons/godottpd/http_request.gd
+++ b/addons/godottpd/http_request.gd
@@ -18,9 +18,10 @@ var path: String
 # The method
 var method: String
 
-# Parameters
+# A dictionary of request (aka. routing) parameters
 var parameters: Dictionary
 
 
+# Override `str()` method, automatically called in `print()` function
 func _to_string() -> String:
-    return "[headers=%s, method='%s', path='%s']" % [headers, method, path]
+    return JSON.print({headers=headers, method=method, path=path})

--- a/addons/godottpd/http_request.gd
+++ b/addons/godottpd/http_request.gd
@@ -17,3 +17,7 @@ var path: String
 
 # The method
 var method: String
+
+
+func _to_string() -> String:
+    return "[headers=%s, method='%s', path='%s']" % [headers, method, path]

--- a/addons/godottpd/http_request.gd
+++ b/addons/godottpd/http_request.gd
@@ -18,6 +18,9 @@ var path: String
 # The method
 var method: String
 
+# Parameters
+var parameters: Dictionary
+
 
 func _to_string() -> String:
     return "[headers=%s, method='%s', path='%s']" % [headers, method, path]

--- a/addons/godottpd/http_request.gd
+++ b/addons/godottpd/http_request.gd
@@ -1,5 +1,5 @@
 # An HTTP request received by the server
-extends Object
+extends Reference
 class_name HttpRequest
 
 

--- a/addons/godottpd/http_response.gd
+++ b/addons/godottpd/http_response.gd
@@ -12,14 +12,86 @@ var server_identifier: String = "GodotTPD"
 var headers: Dictionary = {}
 var cookies: Array = []
 
+func _match_status_code(code: int) -> String:
+	var text: String = "OK"
+	match(code):
+		100: text="Continue"
+		101: text="Switching protocols"
+		102: text="Processing"
+		103: text="Early Hints"
+
+		200: text="OK"
+		201: text="Created"
+		202: text="Accepted"
+		203: text="Non-Authoritative Information"
+		204: text="No Content"
+		205: text="Reset Content"
+		206: text="Partial Content"
+		207: text="Multi-Status"
+		208: text="Already Reported"
+		226: text="IM Used"
+
+		300: text="Multiple Choices"
+		301: text="Moved Permanently"
+		302: text="Found (Previously 'Moved Temporarily')"
+		303: text="See Other"
+		304: text="Not Modified"
+		305: text="Use Proxy"
+		306: text="Switch Proxy"
+		307: text="Temporary Redirect"
+		308: text="Permanent Redirect"
+
+		400: text="Bad Request"
+		401: text="Unauthorized"
+		402: text="Payment Required"
+		403: text="Forbidden"
+		404: text="Not Found"
+		405: text="Method Not Allowed"
+		406: text="Not Acceptable"
+		407: text="Proxy Authentication Required"
+		408: text="Request Timeout"
+		409: text="Conflict"
+		410: text="Gone"
+		411: text="Length Required"
+		412: text="Precondition Failed"
+		413: text="Payload Too Large"
+		414: text="URI Too Long"
+		415: text="Unsupported Media Type"
+		416: text="Range Not Satisfiable"
+		417: text="Expectation Failed"
+		418: text="I'm a Teapot"
+		421: text="Misdirected Request"
+		422: text="Unprocessable Entity"
+		423: text="Locked"
+		424: text="Failed Dependency"
+		425: text="Too Early"
+		426: text="Upgrade Required"
+		428: text="Precondition Required"
+		429: text="Too Many Requests"
+		431: text="Request Header Fields Too Large"
+		451: text="Unavailable For Legal Reasons"
+
+		500: text="Internal Server Error"
+		501: text="Not Implemented"
+		502: text="Bad Gateway"
+		503: text="Service Unavailable"
+		504: text="Gateway Timeout"
+		505: text="HTTP Version Not Supported"
+		506: text="Variant Also Negotiates"
+		507: text="Insufficient Storage"
+		508: text="Loop Detected"
+		510: text="Not Extended"
+		511: text="Network Authentication Required"
+	return text
+
 # Send out a response to the client
 #
 # #### Parameters
 # - status: The HTTP status code to send
 # - data: The body data to send
 # - content_type: The type of the content to send
-func send(status: int, data: String, content_type: String = "text/html") -> void:
-	client.put_data(("HTTP/1.1 %d OK\n" % status).to_ascii())
+func send(status_code: int, data: String = "", content_type: String = "text/html") -> void:
+	client.put_data(("HTTP/1.1 %d %s\n" % [status_code, _match_status_code(status_code)]).to_ascii())
 	client.put_data(("Server: %s\n" % server_identifier).to_ascii())
 	for header in headers.keys():
 		client.put_data(("%s: %s\n" % [header, headers[header]]).to_ascii())
@@ -29,6 +101,9 @@ func send(status: int, data: String, content_type: String = "text/html") -> void
 	client.put_data("Connection: close\n".to_ascii())
 	client.put_data(("Content-Type: %s\n\n" % content_type).to_ascii())
 	client.put_data(data.to_ascii())
+
+func json(status_code: int, data: Dictionary) -> void:
+	send(status_code, JSON.print(data), "application/json")
 
 # Sets the response’s header "field" to "value"
 #

--- a/addons/godottpd/http_response.gd
+++ b/addons/godottpd/http_response.gd
@@ -1,5 +1,5 @@
 # A response object useful to send out responses
-extends Object
+extends Reference
 class_name HttpResponse
 
 

--- a/addons/godottpd/http_response.gd
+++ b/addons/godottpd/http_response.gd
@@ -41,5 +41,20 @@ func set(field: String, value: String) -> void:
 #
 # @name --> the name of the cookie i.e. "user-id"
 # @value --> the value of this cookie i.e. "abcdef"
-func cookie(name: String, value: String) -> void:
-	cookies.append(name+"="+value)
+func cookie(name: String, value: String, options: Dictionary = {}) -> void:
+	var cookie: String = name+"="+value
+	if options.has("domain"): cookie+="; Domain="+options["domain"]
+	if options.has("max-age"): cookie+="; Max-Age="+options["max-age"]
+	if options.has("expires"): cookie+="; Expires="+options["expires"]
+	if options.has("path"): cookie+="; Path="+options["path"]
+	if options.has("secure"): cookie+="; Secure="+options["secure"]
+	if options.has("httpOnly"): cookie+="; HttpOnly="+options["httpOnly"]
+	if options.has("path"): cookie+="; Path="+options["path"]
+	if options.has("sameSite"): 
+		match (options["sameSite"]):
+			true: cookie += "; SameSite=Strict"
+			"lax": cookie += "; SameSite=Lax"
+			"strict": cookie += "; SameSite=Strict"
+			"none": cookie += "; SameSite=None"
+			_: pass
+	cookies.append(cookie)

--- a/addons/godottpd/http_response.gd
+++ b/addons/godottpd/http_response.gd
@@ -18,24 +18,33 @@ var headers: Dictionary = {}
 # Cookies will be automatically sent via "Set-Cookie" headers to clients
 var cookies: Array = []
 
-# Send out a response to the client
+# Send out a raw (Bytes) response to the client
+# Useful to send files faster or raw data which will be converted by the client
 #
 # #### Parameters
 # - status: The HTTP status code to send
-# - data: The body data to send [""]
+# - data: The body data to send []
 # - content_type: The type of the content to send ["text/html"]
-func send(status_code: int, data: String = "", content_type: String = "text/html") -> void:
+func send_raw(status_code: int, data: PoolByteArray = [], content_type: String = "application/octet-stream") -> void:
 	client.put_data(("HTTP/1.1 %d %s\n" % [status_code, _match_status_code(status_code)]).to_ascii())
 	client.put_data(("Server: %s\n" % server_identifier).to_ascii())
 	for header in headers.keys():
 		client.put_data(("%s: %s\n" % [header, headers[header]]).to_ascii())
 	for cookie in cookies:
 		client.put_data(("Set-Cookie: %s\n" % cookie).to_ascii())
-	client.put_data(("Content-Length: %d\n" % data.to_ascii().size()).to_ascii())
+	client.put_data(("Content-Length: %d\n" % data.size()).to_ascii())
 	client.put_data("Connection: close\n".to_ascii())
 	client.put_data(("Content-Type: %s\n\n" % content_type).to_ascii())
-	client.put_data(data.to_ascii())
+	client.put_data(data)
 
+# Send out a response to the client
+#
+# #### Parameters
+# - status: The HTTP status code to send
+# - data: The body data to send []
+# - content_type: The type of the content to send ["text/html"]
+func send(status_code: int, data: String = "", content_type = "text/html") -> void:
+	send_raw(status_code, data.to_ascii(), content_type)
 
 # Send out a JSON response to the client
 # This function will internally call the `send()` method 

--- a/addons/godottpd/http_response.gd
+++ b/addons/godottpd/http_response.gd
@@ -9,6 +9,8 @@ var client: StreamPeer
 # The server identifier to use on responses [GodotTPD]
 var server_identifier: String = "GodotTPD"
 
+var headers: Dictionary = {}
+var cookies: Array = []
 
 # Send out a response to the client
 #
@@ -19,7 +21,25 @@ var server_identifier: String = "GodotTPD"
 func send(status: int, data: String, content_type: String = "text/html") -> void:
 	client.put_data(("HTTP/1.1 %d OK\n" % status).to_ascii())
 	client.put_data(("Server: %s\n" % server_identifier).to_ascii())
+	for header in headers.keys():
+		client.put_data(("%s: %s\n" % [header, headers[header]]).to_ascii())
+	for cookie in cookies:
+		client.put_data(("Set-Cookie: %s\n" % cookie).to_ascii())
 	client.put_data(("Content-Length: %d\n" % data.to_ascii().size()).to_ascii())
 	client.put_data("Connection: close\n".to_ascii())
 	client.put_data(("Content-Type: %s\n\n" % content_type).to_ascii())
 	client.put_data(data.to_ascii())
+
+# Sets the response’s header "field" to "value"
+#
+# @field --> the name of the header i.e. "Accept-Type"
+# @value --> the value of this header i.e. "application/json"
+func set(field: String, value: String) -> void:
+	headers[field] = value
+
+# Sets cookie "name" to "value"
+#
+# @name --> the name of the cookie i.e. "user-id"
+# @value --> the value of this cookie i.e. "abcdef"
+func cookie(name: String, value: String) -> void:
+	cookies.append(name+"="+value)

--- a/addons/godottpd/http_response.gd
+++ b/addons/godottpd/http_response.gd
@@ -22,8 +22,8 @@ var cookies: Array = []
 #
 # #### Parameters
 # - status: The HTTP status code to send
-# - data: The body data to send
-# - content_type: The type of the content to send
+# - data: The body data to send [""]
+# - content_type: The type of the content to send ["text/html"]
 func send(status_code: int, data: String = "", content_type: String = "text/html") -> void:
 	client.put_data(("HTTP/1.1 %d %s\n" % [status_code, _match_status_code(status_code)]).to_ascii())
 	client.put_data(("Server: %s\n" % server_identifier).to_ascii())
@@ -41,8 +41,8 @@ func send(status_code: int, data: String = "", content_type: String = "text/html
 # This function will internally call the `send()` method 
 #
 # #### Parameters
-# @status_code --> The HTTP status code to send
-# @data --> The body data to send, must be a Dictionary or an Array
+# - status_code: The HTTP status code to send
+# - data: The body data to send, must be a Dictionary or an Array
 func json(status_code: int, data) -> void:
 	send(status_code, JSON.print(data), "application/json")
 
@@ -50,16 +50,19 @@ func json(status_code: int, data) -> void:
 # Sets the response’s header "field" to "value"
 #
 # #### Parameters
-# @field --> the name of the header i.e. "Accept-Type"
-# @value --> the value of this header i.e. "application/json"
+# - field: the name of the header i.e. "Accept-Type"
+# - value: the value of this header i.e. "application/json"
 func set(field: String, value: String) -> void:
 	headers[field] = value
 
 
 # Sets cookie "name" to "value"
 #
-# @name --> the name of the cookie i.e. "user-id"
-# @value --> the value of this cookie i.e. "abcdef"
+# #### Parameters
+# - name: the name of the cookie i.e. "user-id"
+# - value: the value of this cookie i.e. "abcdef"
+# - options: a Dictionary of ![cookie attributes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes) 
+#			 for this specific cookie, in the { "secure" : "true" } format 
 func cookie(name: String, value: String, options: Dictionary = {}) -> void:
 	var cookie: String = name+"="+value
 	if options.has("domain"): cookie+="; Domain="+options["domain"]
@@ -82,10 +85,9 @@ func cookie(name: String, value: String, options: Dictionary = {}) -> void:
 # Automatically matches a "status_code" to an RFC 7231 compliant "status_text"
 #
 # #### Parameters
-# @code --> HTTP Status Code to be matched
+# - code: HTTP Status Code to be matched
 # 
-# #### Returns
-# @String --> the matched "status_text"
+# Returns: the matched "status_text"
 func _match_status_code(code: int) -> String:
 	var text: String = "OK"
 	match(code):

--- a/addons/godottpd/http_router.gd
+++ b/addons/godottpd/http_router.gd
@@ -1,5 +1,5 @@
 # A base class for all HTTP routers
-extends Object
+extends Reference
 class_name HttpRouter
 
 

--- a/addons/godottpd/http_server.gd
+++ b/addons/godottpd/http_server.gd
@@ -2,8 +2,8 @@
 extends Node
 class_name HttpServer
 
-# If debug messages should be printed in console on requests
-var _debug: bool = false
+# If `HttpRequest`s and `HttpResponse`s should be logged
+var _logging: bool = false
 
 # The ip address to bind the server to. Use * for all IP addresses [*]
 var bind_address: String = "*"
@@ -40,11 +40,13 @@ func _init(_debug: bool = false) -> void:
 	_header_regex.compile("^(?<key>[^:]+): (?<value>.+)$")
 
 # Print a debug message in console, if the debug mode is enabled
+# 
+# #### Parameters
+# - message: The message to be printed (only in debug mode)
 func _print_debug(message: String) -> void:
-	if _debug:
-		var time = OS.get_datetime()
-		var time_return = "%02d-%02d-%02d %02d:%02d:%02d" % [time.year, time.month, time.day, time.hour, time.minute, time.second]
-		print("[SERVER] ",time_return," >> ", message)
+	var time = OS.get_datetime()
+	var time_return = "%02d-%02d-%02d %02d:%02d:%02d" % [time.year, time.month, time.day, time.hour, time.minute, time.second]
+	print_debug("[SERVER] ",time_return," >> ", message)
 
 # Register a new router to handle a specific path
 #

--- a/addons/godottpd/http_server.gd
+++ b/addons/godottpd/http_server.gd
@@ -28,6 +28,8 @@ var _method_regex: RegEx = RegEx.new()
 # A regex for header lines
 var _header_regex: RegEx = RegEx.new()
 
+# The base path used in a project to serve files
+var _local_base_path: String = "res://src"
 
 # Compile the required regex
 func _init() -> void:
@@ -143,4 +145,15 @@ func _perform_current_request(client: StreamPeer, request: HttpRequest):
 					found = true
 					router.router.handle_options(request, response)
 	if not found:
-		response.send(404, "Not found")
+		if not serve_file(request, response):
+			response.send(404, "Not found")
+
+func serve_file(request: HttpRequest, response: HttpResponse) -> bool:
+	var file_path: String = request.path+".html" if request.path.get_extension() != "html" else request.path
+	var file = File.new()
+	var file_opened: bool = not bool(file.open(_local_base_path+"/"+file_path, File.READ))
+	if file_opened:
+		var content = file.get_as_text()
+		file.close()
+		response.send(200, content)
+	return file_opened

--- a/addons/godottpd/http_server.gd
+++ b/addons/godottpd/http_server.gd
@@ -175,8 +175,15 @@ func _perform_current_request(client: StreamPeer, request: HttpRequest):
 	if not found:	
 		response.send(404, "Not found")
 
+
 # Serve a file in the local system.
 # Files to be exposed are only rooted from the @_local_base_path for security
+#
+# #### Parameters
+# @request_path --> The path to the requested file. It will be taken from the `HttpRequest.path`
+# 					attribute and rooted from the @_local_base_path
+# #### Returns
+# @String --> the content of the file to be served, if it exists and is accessible, else ""
 func serve_file(request_path: String) -> String:
 	var content: String = ""
 	var file = File.new()
@@ -190,8 +197,13 @@ func serve_file(request_path: String) -> String:
 # Converts a URL path to @regexp RegExp, providing a mechanism to fetch groups from the expression
 # indexing each parameter by name in the @params array
 #
-# @regexp --> the output expression as a String, to be compiled in RegExp
-# @params --> an Array of parameters, indexed by names. Can be fetched using `RegExp.get_string()` method
+# #### Parameters
+# @path --> The path of the HttpRequest
+# 
+# #### Returns
+# @Array --> A 2D array, containing a @regexp String and Dictionary of @params
+# [0] = @regexp --> the output expression as a String, to be compiled in RegExp
+# [1] = @params --> an Array of parameters, indexed by names. Can be fetched using `RegExp.get_string()` method
 # ex. "/user/:id" --> "^/user/(?<id>([^/#?]+?))[/#?]?$"
 func _path_to_regexp(path: String) -> Array:
 	var regexp: String = "^"

--- a/addons/godottpd/http_server.gd
+++ b/addons/godottpd/http_server.gd
@@ -102,7 +102,7 @@ func stop():
 #
 # #### Parameters
 # - client: The client that send the request
-# - request: The received request 
+# - request: The received request as a String
 func _handle_request(client: StreamPeer, request_string: String):
 	var request = HttpRequest.new()
 	for line in request_string.split("\r\n"):
@@ -187,10 +187,9 @@ func _perform_current_request(client: StreamPeer, request: HttpRequest):
 # Files to be exposed are only rooted from the @_local_base_path for security
 #
 # #### Parameters
-# @request_path --> The path to the requested file. It will be taken from the `HttpRequest.path`
+# - request_path: The path to the requested file. It will be taken from the `HttpRequest.path`
 # 					attribute and rooted from the @_local_base_path
-# #### Returns
-# @String --> the content of the file to be served, if it exists and is accessible, else ""
+# Returns: the content of the file to be served, if it exists and is accessible, else ""
 func serve_file(request_path: String) -> String:
 	var content: String = ""
 	var file = File.new()
@@ -205,13 +204,12 @@ func serve_file(request_path: String) -> String:
 # indexing each parameter by name in the @params array
 #
 # #### Parameters
-# @path --> The path of the HttpRequest
+# - path: The path of the HttpRequest
 # 
-# #### Returns
-# @Array --> A 2D array, containing a @regexp String and Dictionary of @params
-# [0] = @regexp --> the output expression as a String, to be compiled in RegExp
-# [1] = @params --> an Array of parameters, indexed by names. Can be fetched using `RegExp.get_string()` method
-# ex. "/user/:id" --> "^/user/(?<id>([^/#?]+?))[/#?]?$"
+# Returns: A 2D array, containing a @regexp String and Dictionary of @params
+# 			[0] = @regexp --> the output expression as a String, to be compiled in RegExp
+# 			[1] = @params --> an Array of parameters, indexed by names
+# 			ex. "/user/:id" --> "^/user/(?<id>([^/#?]+?))[/#?]?$"
 func _path_to_regexp(path: String) -> Array:
 	var regexp: String = "^"
 	var params: Array = []
@@ -220,11 +218,11 @@ func _path_to_regexp(path: String) -> Array:
 	for fragment in fragments:
 		if fragment.left(1) == ":":
 			fragment = fragment.lstrip(":")
-			regexp+="/(?<%s>([^/#?]+?))"%fragment
+			regexp += "/(?<%s>([^/#?]+?))" % fragment
 			params.append(fragment)
 		else:
-			regexp+="/"+fragment
-	regexp+="[/#?]?$"
+			regexp += "/" + fragment
+	regexp += "[/#?]?$"
 	return [regexp, params]
 
 
@@ -232,10 +230,9 @@ func _path_to_regexp(path: String) -> Array:
 # building a Query Dictionary of param:value pairs
 #
 # #### Parameters
-# @query_string --> the query string, extracted from the HttpRequest.path
+# - query_string: the query string, extracted from the HttpRequest.path
 #
-# #### Returns
-# @Dictionary --> A Dictionary of param:value pairs
+# Returns: A Dictionary of param:value pairs
 func _extract_query_params(query_string: String) -> Dictionary:
 	var query: Dictionary = {}
 	if query_string == "":

--- a/addons/godottpd/http_server.gd
+++ b/addons/godottpd/http_server.gd
@@ -168,7 +168,7 @@ func _perform_current_request(client: StreamPeer, request: HttpRequest):
 					router.router.handle_options(request, response)
 	if not found:
 		if not request.path.get_extension() in ["gd"]:
-			var content: String = serve_file(request)
+			var content: String = serve_file(request.path)
 			if content != "":
 				found = true
 				response.send(200, content, "text/"+request.path.get_extension())
@@ -177,10 +177,10 @@ func _perform_current_request(client: StreamPeer, request: HttpRequest):
 
 # Serve a file in the local system.
 # Files to be exposed are only rooted from the @_local_base_path for security
-func serve_file(request: HttpRequest) -> String:
+func serve_file(request_path: String) -> String:
 	var content: String = ""
 	var file = File.new()
-	var file_opened: bool = not bool(file.open(_local_base_path+"/"+request.path, File.READ))
+	var file_opened: bool = not bool(file.open(_local_base_path+"/"+request_path, File.READ))
 	if file_opened:
 		content = file.get_as_text()
 		file.close()

--- a/project.godot
+++ b/project.godot
@@ -24,6 +24,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/godottpd/http_router.gd"
 }, {
+"base": "Object",
+"class": "HttpFileRouter",
+"language": "GDScript",
+"path": "res://addons/godottpd/http_file_router.gd"
+}, {
 "base": "Node",
 "class": "HttpServer",
 "language": "GDScript",


### PR DESCRIPTION
Hi!
I've been using your plugin as a starting point for a personal project.
I'm experimenting in using GDScript as a scripting language to make an HTTP REST microservices.
Currently I've achieved a prototype of an "identity provider", leveraging your addon for the server part and adding some more features just like ExpressJS (since you are following that structure ).
I've also implemented my gdscript JWT library and tested it with your headers management (and the cookies management I've implemented).
You can test my project downloding my zip.
To run it the way it is intended, you can just extract the whole zip in a folder and at the root run 
```
godot -s ./src/test.gd --no-window
```
if you have `godot` as an environment variable pointing to Godot Engine binaries.
Here you can also see a video showcasing the demo:

https://user-images.githubusercontent.com/45271396/152658818-8c1577f3-ec4a-4632-bc68-90639ff5041e.mp4


As you can see it runs pretty well, and since I followed your styling I wanted to propose my changes as 
a PR, if you'd like to accept it.
Most of them are new features:
* auto-matching `.cookie()` method to set a cookie which will then be send in the response
* request parameters (referring to the routing ones, not query parameters)
* regexp group compilation of request path, in order to automatically create `request.parameters` from paths like `/user/:id/name/:name`
* local .html files serving, which will be serve specifically from the "res://src" path and will be served as an alternative to the 404 response (if there are no paths routed)
* configurable debug mode for server debugging, printing debug messages in a formatted string

A few of them are just qol updates:
* `response.send()` will now automatically match a response code to its relative response text, and the `data` parameter is optional
* `response.json()` automatically sends a response following the JSON standard using a Dictionary/Array as `data` and `application/json` as content type

I hope you'll find them useful. I'm willing to support these developments if accepted.
For sure I'll keep on using your addon and adding more features since you did a really useful and amazing job!
[http-server.zip](https://github.com/deep-entertainment/godottpd/files/8008824/http-server.zip)
