### PR TITLE
fix: use carriage returns in response

### DIFF
--- a/addons/godottpd/http_response.gd
+++ b/addons/godottpd/http_response.gd
@@ -26,15 +26,15 @@ var cookies: Array = []
 # - data: The body data to send []
 # - content_type: The type of the content to send ["text/html"]
 func send_raw(status_code: int, data: PoolByteArray = [], content_type: String = "application/octet-stream") -> void:
-	client.put_data(("HTTP/1.1 %d %s\n" % [status_code, _match_status_code(status_code)]).to_ascii())
-	client.put_data(("Server: %s\n" % server_identifier).to_ascii())
+	client.put_data(("HTTP/1.1 %d %s\r\n" % [status_code, _match_status_code(status_code)]).to_ascii())
+	client.put_data(("Server: %s\r\n" % server_identifier).to_ascii())
 	for header in headers.keys():
-		client.put_data(("%s: %s\n" % [header, headers[header]]).to_ascii())
+		client.put_data(("%s: %s\r\n" % [header, headers[header]]).to_ascii())
 	for cookie in cookies:
-		client.put_data(("Set-Cookie: %s\n" % cookie).to_ascii())
-	client.put_data(("Content-Length: %d\n" % data.size()).to_ascii())
-	client.put_data("Connection: close\n".to_ascii())
-	client.put_data(("Content-Type: %s\n\n" % content_type).to_ascii())
+		client.put_data(("Set-Cookie: %s\r\n" % cookie).to_ascii())
+	client.put_data(("Content-Length: %d\r\n" % data.size()).to_ascii())
+	client.put_data("Connection: close\r\n".to_scii())
+	client.put_data(("Content-Type: %s\r\n\r\n" % content_type).to_ascii())
 	client.put_data(data)
 
 # Send out a response to the client

--- a/addons/godottpd/http_response.gd
+++ b/addons/godottpd/http_response.gd
@@ -33,7 +33,7 @@ func send_raw(status_code: int, data: PoolByteArray = [], content_type: String =
 	for cookie in cookies:
 		client.put_data(("Set-Cookie: %s\r\n" % cookie).to_ascii())
 	client.put_data(("Content-Length: %d\r\n" % data.size()).to_ascii())
-	client.put_data("Connection: close\r\n".to_scii())
+	client.put_data("Connection: close\r\n".to_ascii())
 	client.put_data(("Content-Type: %s\r\n\r\n" % content_type).to_ascii())
 	client.put_data(data)
 


### PR DESCRIPTION
The HTTP 1.1 standard requires response header fields (and blank lines) to be terminated in CRLF (\r\n). Some http request libraries have taken this to heart and throw errors when this is not the case, or require a special flag to bypass the issue. Reference: https://www.rfc-editor.org/rfc/rfc2616#section-2.2

Examples of libraries that enforce this in node.js: axios, http

DISCLAIMER: I have only tested this in OSX. I imagine it *_should_* be system agnostic, but this should be verified before merging. I will try to test it in linux as well, but I don't have easy access (or the inclination to get access) to a windows box

Great job btw, the addon is super simple and elegant. My use case was fairly complex and this addon made my life so much easier, so kudos to the team