### PR TITLE
Add `break` in `http_server.gd` for easier routing

### DIFF
--- a/addons/godottpd/http_server.gd
+++ b/addons/godottpd/http_server.gd
@@ -185,6 +185,7 @@ func _perform_current_request(client: StreamPeer, request: HttpRequest):
 				"OPTIONS":
 					found = true
 					router.router.handle_options(request, response)
+			break
 	if not found:	
 		response.send(404, "Not found")
 


### PR DESCRIPTION
This lets you setup an HTTP server like this:
```gd
server.register_router('/api/v2', new_api_router) # most specific first
server.register_router('/api', legacy_api_router)
server.register_router('/*', file_router) # least specific last
```
Fetching `/api/v2` will only invoke the `new_api_router` instead of invoking all matching routers and potentially getting multiple responses (the old behavior).

The unintuitive part about this is that the routers need to be registered from most specific from least specific. Maybe the `register_router` function can be updated to automatically do that but the workaround is super easy.