### PR TITLE
feat: added cors support

### DIFF
--- a/addons/godottpd/http_response.gd
+++ b/addons/godottpd/http_response.gd
@@ -21,6 +21,12 @@ var cookies: Array = []
 # Origins allowed to call this resource
 var access_control_origin = "*"
 
+# Comma separed methods for the access control
+var access_control_allowed_methods = "POST, GET, OPTIONS"
+
+# Comma separed headers for the access control
+var access_control_allowed_headers = "content-type"
+
 # Send out a raw (Bytes) response to the client
 # Useful to send files faster or raw data which will be converted by the client
 #
@@ -38,8 +44,8 @@ func send_raw(status_code: int, data: PackedByteArray = PackedByteArray([]), con
 	client.put_data(("Content-Length: %d\r\n" % data.size()).to_ascii_buffer())
 	client.put_data("Connection: close\r\n".to_ascii_buffer())
 	client.put_data(("Access-Control-Allow-Origin: %s\r\n" % access_control_origin).to_ascii_buffer())
-	client.put_data(("Access-Control-Allow-Methods: POST, GET, OPTIONS\r\n").to_ascii_buffer())
-	client.put_data(("Access-Control-Allow-Headers: content-type\r\n").to_ascii_buffer())
+	client.put_data(("Access-Control-Allow-Methods: %s\r\n" % access_control_allowed_methods).to_ascii_buffer())
+	client.put_data(("Access-Control-Allow-Headers: %s\r\n" % access_control_allowed_headers).to_ascii_buffer())
 	client.put_data(("Content-Type: %s\r\n\r\n" % content_type).to_ascii_buffer())
 	client.put_data(data)
 

--- a/addons/godottpd/http_response.gd
+++ b/addons/godottpd/http_response.gd
@@ -18,6 +18,9 @@ var headers: Dictionary = {}
 # Cookies will be automatically sent via "Set-Cookie" headers to clients
 var cookies: Array = []
 
+# Origins allowed to call this resource
+var access_control_origin = "*"
+
 # Send out a raw (Bytes) response to the client
 # Useful to send files faster or raw data which will be converted by the client
 #
@@ -34,6 +37,9 @@ func send_raw(status_code: int, data: PackedByteArray = PackedByteArray([]), con
 		client.put_data(("Set-Cookie: %s\r\n" % cookie).to_ascii_buffer())
 	client.put_data(("Content-Length: %d\r\n" % data.size()).to_ascii_buffer())
 	client.put_data("Connection: close\r\n".to_ascii_buffer())
+	client.put_data(("Access-Control-Allow-Origin: %s\r\n" % access_control_origin).to_ascii_buffer())
+	client.put_data(("Access-Control-Allow-Methods: POST, GET, OPTIONS\r\n").to_ascii_buffer())
+	client.put_data(("Access-Control-Allow-Headers: content-type\r\n").to_ascii_buffer())
 	client.put_data(("Content-Type: %s\r\n\r\n" % content_type).to_ascii_buffer())
 	client.put_data(data)
 

--- a/addons/godottpd/http_server.gd
+++ b/addons/godottpd/http_server.gd
@@ -36,6 +36,12 @@ var _local_base_path: String = "res://src"
 # list of host allowed to call the server
 var _allowed_origins: PackedStringArray = []
 
+# Comma separed methods for the access control
+var _access_control_allowed_methods = "POST, GET, OPTIONS"
+
+# Comma separed headers for the access control
+var _access_control_allowed_headers = "content-type"
+
 # Compile the required regex
 func _init(_logging: bool = false):
 	self._logging = _logging
@@ -175,6 +181,9 @@ func _perform_current_request(client: StreamPeer, request: HttpRequest):
 		is_allowed_origin = true
 		response.access_control_origin = origin
 
+	response.access_control_allowed_methods = _access_control_allowed_methods
+	response.access_control_allowed_headers = _access_control_allowed_headers
+
 	for router in self._routers:
 		var matches = router.path.search(request.path)
 		if matches:
@@ -247,8 +256,11 @@ func _path_to_regexp(path: String, should_match_subfolders: bool = false) -> Arr
 	return [regexp, params]
 
 
-func enable_cors(allowed_origins: PackedStringArray):
+func enable_cors(allowed_origins: PackedStringArray, access_control_allowed_methods : String = "POST, GET, OPTIONS", access_control_allowed_headers : String = "content-type"):
 	_allowed_origins = allowed_origins
+	_access_control_allowed_methods = access_control_allowed_methods
+	_access_control_allowed_headers = access_control_allowed_headers
+
 
 # Extracts query parameters from a String query, 
 # building a Query Dictionary of param:value pairs

--- a/example/scripts/godot_http_server_example.gd
+++ b/example/scripts/godot_http_server_example.gd
@@ -5,7 +5,8 @@ extends Node
 func _ready() -> void:
 	var server = HttpServer.new()
 	server.register_router("/", MyExampleRouter.new())
-	add_child(server)
+	add_child(server)	
+	server.enable_cors(["http://localhost:8060"])
 	server.start()
 
 


### PR DESCRIPTION
Added "Access-Control-Allow-Origin" before sending responses, default value *, at the moment of receiving the request and parsing it I validate if the origin of the request comes from the allowed_origins set by the user calling "HttpServer.enable_cors" before starting the server, If its an allowed origin the response of the request will include the Access-Control-Allow-Origin with the origin as value

Remake of the #10 PR due git rebase problems