### PR TITLE
feat: Support for viewing documentation in-engine

### DIFF
--- a/addons/godottpd/http_file_router.gd
+++ b/addons/godottpd/http_file_router.gd
@@ -1,6 +1,6 @@
 ## Class inheriting HttpRouter for handling file serving requests
 ##
-## NOTE: This class mainlly handles behind the scenes stuff.
+## NOTE: This class mainly handles behind the scenes stuff.
 class_name HttpFileRouter
 extends HttpRouter
 
@@ -44,7 +44,8 @@ func _init(
 
 ## Handle a GET request
 ## [br]
-## [br][param request] - The request
+## [br][param request] - The request from the client
+## [br][param response] - The response to send to the clinet
 func handle_get(request: HttpRequest, response: HttpResponse) -> void:
 	var serving_path: String = path + request.path
 	var file_exists: bool = _file_exists(serving_path)

--- a/addons/godottpd/http_file_router.gd
+++ b/addons/godottpd/http_file_router.gd
@@ -1,31 +1,32 @@
-# Class inheriting HttpRouter for handling file serving requests
-extends HttpRouter
+## Class inheriting HttpRouter for handling file serving requests
+##
+## NOTE: This class mainlly handles behind the scenes stuff.
 class_name HttpFileRouter
+extends HttpRouter
 
-# Full path to the folder which will be exposed to web
+## Full path to the folder which will be exposed to web
 var path: String = ""
 
-# Relative path to the index page, which will be served when a request is made to "/" (server root)
+## Relative path to the index page, which will be served when a request is made to "/" (server root)
 var index_page: String = "index.html"
 
-# Relative path to the fallback page which will be served if the requested file was not found
+## Relative path to the fallback page which will be served if the requested file was not found
 var fallback_page: String = ""
 
-# An ordered list of extensions that will be checked
-# if no file extension is provided by the request
+## An ordered list of extensions that will be checked
+## if no file extension is provided by the request
 var extensions: PackedStringArray = ["html"]
 
-# A list of extensions that will be excluded if requested
+## A list of extensions that will be excluded if requested
 var exclude_extensions: PackedStringArray = []
 
-# Creates an HttpFileRouter intance
-#
-# #### Parameters
-# - path: Full path to the folder which will be exposed to web
-# - options: Optional Dictionary of options which can be configured.
-# 	- fallback_page: Full path to the fallback page which will be served if the requested file was not found
-#	- extensions: A list of extensions that will be checked if no file extension is provided by the request
-# 	- exclude_extensions: A list of extensions that will be excluded if requested
+## Creates an HttpFileRouter intance
+## [br]
+## [br][param path] - Full path to the folder which will be exposed to web.
+## [br][param options] - Optional Dictionary of options which can be configured:
+## [br] - [param fallback_page]: Full path to the fallback page which will be served if the requested file was not found
+## [br] - [param extensions]: A list of extensions that will be checked if no file extension is provided by the request
+## [br]	- [param exclude_extensions]: A list of extensions that will be excluded if requested
 func _init(
 	path: String,
 	options: Dictionary = {
@@ -41,7 +42,9 @@ func _init(
 	self.extensions = options.get("extensions", [])
 	self.exclude_extensions = options.get("exclude_extensions", [])
 
-# Handle a GET request
+## Handle a GET request
+## [br]
+## [br][param request] - The request
 func handle_get(request: HttpRequest, response: HttpResponse) -> void:
 	var serving_path: String = path + request.path
 	var file_exists: bool = _file_exists(serving_path)

--- a/addons/godottpd/http_request.gd
+++ b/addons/godottpd/http_request.gd
@@ -1,53 +1,53 @@
-# An HTTP request received by the server
-extends RefCounted
+## An HTTP request received by the server
 class_name HttpRequest
+extends RefCounted
 
 
-# A dictionary of the headers of the request
+## A dictionary of the headers of the request
 var headers: Dictionary
 
-# The received raw body
+## The received raw body
 var body: String
 
-# A match object of the regular expression that matches the path
+## A match object of the regular expression that matches the path
 var query_match: RegExMatch
 
-# The path that matches the router path
+## The path that matches the router path
 var path: String
 
-# The method
+## The method
 var method: String
 
-# A dictionary of request (aka. routing) parameters
+## A dictionary of request (aka. routing) parameters
 var parameters: Dictionary
 
-# A dictionary of request query parameters
+## A dictionary of request query parameters
 var query: Dictionary
 
-# Returns the body object based on the raw body and the content type of the request
+## Returns the body object based on the raw body and the content type of the request
 func get_body_parsed() -> Variant:
 	var content_type: String = ""
-	
+
 	if(headers.has("content-type")):
 		content_type = headers["content-type"]
 	elif(headers.has("Content-Type")):
 		content_type = headers["Content-Type"]
-		
+
 	if(content_type == "application/json"):
 		return JSON.parse_string(body)
 
 	if(content_type == "application/x-www-form-urlencoded"):
 		var data = {}
-		
+
 		for body_part in  body.split("&"):
 			var key_and_value = body_part.split("=")
 			data[key_and_value[0]] = key_and_value[1]
-		
+
 		return data
-	
+
 	# Not supported contenty type parsing... for now
 	return null
 
-# Override `str()` method, automatically called in `print()` function
+# #Override `str()` method, automatically called in `print()` function
 func _to_string() -> String:
 	return JSON.stringify({headers=headers, method=method, path=path})

--- a/addons/godottpd/http_request.gd
+++ b/addons/godottpd/http_request.gd
@@ -48,6 +48,6 @@ func get_body_parsed() -> Variant:
 	# Not supported contenty type parsing... for now
 	return null
 
-# #Override `str()` method, automatically called in `print()` function
+## Override `str()` method, automatically called in `print()` function
 func _to_string() -> String:
 	return JSON.stringify({headers=headers, method=method, path=path})

--- a/addons/godottpd/http_response.gd
+++ b/addons/godottpd/http_response.gd
@@ -1,39 +1,37 @@
-# A response object useful to send out responses
-extends RefCounted
+## A response object useful to send out responses
 class_name HttpResponse
+extends RefCounted
 
 
-# The client currently talking to the server
+## The client currently talking to the server
 var client: StreamPeer
 
-# The server identifier to use on responses [GodotTPD]
+## The server identifier to use on responses [GodotTPD]
 var server_identifier: String = "GodotTPD"
 
-# A dictionary of headers
-# Headers can be set using the `set(name, value)` function
+## A dictionary of headers
+## [br] Headers can be set using the `set(name, value)` function
 var headers: Dictionary = {}
 
-# An array of cookies
-# Cookies can be set using the `cookie(name, value, options)` function
-# Cookies will be automatically sent via "Set-Cookie" headers to clients
+## An array of cookies
+## [br] Cookies can be set using the `cookie(name, value, options)` function
+## [br] Cookies will be automatically sent via "Set-Cookie" headers to clients
 var cookies: Array = []
 
-# Origins allowed to call this resource
+## Origins allowed to call this resource
 var access_control_origin = "*"
 
-# Comma separed methods for the access control
+## Comma separed methods for the access control
 var access_control_allowed_methods = "POST, GET, OPTIONS"
 
-# Comma separed headers for the access control
+## Comma separed headers for the access control
 var access_control_allowed_headers = "content-type"
 
-# Send out a raw (Bytes) response to the client
-# Useful to send files faster or raw data which will be converted by the client
-#
-# #### Parameters
-# - status: The HTTP status code to send
-# - data: The body data to send []
-# - content_type: The type of the content to send ["text/html"]
+## Send out a raw (Bytes) response to the client
+## [br] Useful to send files faster or raw data which will be converted by the client
+## [br][param status] - The HTTP Status code to send
+## [br][param data] - The body data to send
+## [br][param content_type] - The type of content to send.
 func send_raw(status_code: int, data: PackedByteArray = PackedByteArray([]), content_type: String = "application/octet-stream") -> void:
 	client.put_data(("HTTP/1.1 %d %s\r\n" % [status_code, _match_status_code(status_code)]).to_ascii_buffer())
 	client.put_data(("Server: %s\r\n" % server_identifier).to_ascii_buffer())
@@ -49,41 +47,37 @@ func send_raw(status_code: int, data: PackedByteArray = PackedByteArray([]), con
 	client.put_data(("Content-Type: %s\r\n\r\n" % content_type).to_ascii_buffer())
 	client.put_data(data)
 
-# Send out a response to the client
-#
-# #### Parameters
-# - status: The HTTP status code to send
-# - data: The body data to send []
-# - content_type: The type of the content to send ["text/html"]
+## Send out a response to the client
+## [br]
+## [br][param status_code] - The HTTP status code to send
+## [br][param data] - The body to send
+## [br][param content_type] - The type of the content to send
 func send(status_code: int, data: String = "", content_type = "text/html") -> void:
 	send_raw(status_code, data.to_ascii_buffer(), content_type)
 
-# Send out a JSON response to the client
-# This function will internally call the `send()` method
-#
-# #### Parameters
-# - status_code: The HTTP status code to send
-# - data: The body data to send, must be a Dictionary or an Array
+## Send out a JSON response to the client
+## [br] This function will internally call the [method send]
+## [br]
+## [br][param status_code] - The HTTP status code to send
+## [br][param data] - The body to send
 func json(status_code: int, data) -> void:
 	send(status_code, JSON.stringify(data), "application/json")
 
 
-# Sets the response’s header "field" to "value"
-#
-# #### Parameters
-# - field: the name of the header i.e. "Accept-Type"
-# - value: the value of this header i.e. "application/json"
+## Sets the response’s header "field" to "value"
+## [br]
+## [br][param field] - The name of the header. i.e. [code]Accept-Type[/code]
+## [br][param value] - The value of this header. i.e. [code]application/json[/code]
 func set(field: StringName, value: Variant) -> void:
 	headers[field] = value
 
 
-# Sets cookie "name" to "value"
-#
-# #### Parameters
-# - name: the name of the cookie i.e. "user-id"
-# - value: the value of this cookie i.e. "abcdef"
-# - options: a Dictionary of ![cookie attributes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes)
-#			 for this specific cookie, in the { "secure" : "true" } format
+## Sets cookie "name" to "value"
+## [br]
+## [br][param name] - The name of the cookie. i.e. [code]user-id[/code]
+## [br][param value] - The value of this cookie. i.e. [code]abcdef[/code]
+## [br][param options] - A Dictionary of [url=https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes]cookie attributes[/url]
+## for this specific cokkie in the [code]{ "secure" : "true"}[/code] format.
 func cookie(name: String, value: String, options: Dictionary = {}) -> void:
 	var cookie: String = name+"="+value
 	if options.has("domain"): cookie+="; Domain="+options["domain"]
@@ -102,12 +96,10 @@ func cookie(name: String, value: String, options: Dictionary = {}) -> void:
 	cookies.append(cookie)
 
 
-# Automatically matches a "status_code" to an RFC 7231 compliant "status_text"
-#
-# #### Parameters
-# - code: HTTP Status Code to be matched
-#
-# Returns: the matched "status_text"
+## Automatically matches a "status_code" to an RFC 7231 compliant "status_text"
+## [br]
+## [br][param code] - The HTTP Status code to be matched
+## [br]Returns: the matched [code]status_text[/code]
 func _match_status_code(code: int) -> String:
 	var text: String = "OK"
 	match(code):

--- a/addons/godottpd/http_router.gd
+++ b/addons/godottpd/http_router.gd
@@ -1,32 +1,77 @@
-# A base class for all HTTP routers
-extends RefCounted
+## A base class for all HTTP routers
+##
+## This router handles all the requests that the client sends to the server.
+## [br]NOTE: This class is meant to be expanded upon instead of used directly.
+## [br]Usage:
+## [codeblock]
+## class_name MyCustomRouter
+## extends HttpRouter
+##
+## func handle_get(request: HttpRequest, response: HttpResponse) -> void:
+##     response.send(200, "Hello World")
+## [/codeblock]
 class_name HttpRouter
+extends RefCounted
 
 
-# Handle a GET request
+## Handle a GET request
+## [br]
+## [br][param request] - The request from the client
+## [br][param response] - The node to send the response back to the client
+@warning_ignore("unused_parameter")
 func handle_get(request: HttpRequest, response: HttpResponse) -> void:
 	response.send(405, "GET not allowed")
 
-# Handle a POST request
+
+## Handle a POST request
+## [br]
+## [br][param request] - The request from the client
+## [br][param response] - The node to send the response back to the client
+@warning_ignore("unused_parameter")
 func handle_post(request: HttpRequest, response: HttpResponse) -> void:
 	response.send(405, "POST not allowed")
 
-# Handle a HEAD request
+
+## Handle a HEAD request
+## [br]
+## [br][param request] - The request from the client
+## [br][param response] - The node to send the response back to the client
+@warning_ignore("unused_parameter")
 func handle_head(request: HttpRequest, response: HttpResponse) -> void:
 	response.send(405, "HEAD not allowed")
 
-# Handle a PUT request
+
+## Handle a PUT request
+## [br]
+## [br][param request] - The request from the client
+## [br][param response] - The node to send the response back to the client
+@warning_ignore("unused_parameter")
 func handle_put(request: HttpRequest, response: HttpResponse) -> void:
 	response.send(405, "PUT not allowed")
 
-# Handle a PATCH request
+
+## Handle a PATCH request
+## [br]
+## [br][param request] - The request from the client
+## [br][param response] - The node to send the response back to the client
+@warning_ignore("unused_parameter")
 func handle_patch(request: HttpRequest, response: HttpResponse) -> void:
 	response.send(405, "PATCH not allowed")
 
-# Handle a DELETE request
+
+## Handle a DELETE request
+## [br]
+## [br][param request] - The request from the client
+## [br][param response] - The node to send the response back to the client
+@warning_ignore("unused_parameter")
 func handle_delete(request: HttpRequest, response: HttpResponse) -> void:
 	response.send(405, "DELETE not allowed")
-	
-# Handle an OPTIONS request
+
+
+## Handle an OPTIONS request
+## [br]
+## [br][param request] - The request from the client
+## [br][param response] - The node to send the response back to the client
+@warning_ignore("unused_parameter")
 func handle_options(request: HttpRequest, response: HttpResponse) -> void:
 	response.send(405, "OPTIONS not allowed")

--- a/addons/godottpd/http_server.gd
+++ b/addons/godottpd/http_server.gd
@@ -1,6 +1,6 @@
 ## A routable HTTP server for Godot
 ##
-## Controlls a back-end localhost server.
+## Provides a web server with routes for specific endpoints
 ## [br]Example usage:
 ## [codeblock]
 ## var server := HttpServer.new()
@@ -271,8 +271,8 @@ func _path_to_regexp(path: String, should_match_subfolders: bool = false) -> Arr
 
 ## Enable CORS (Cross-origin resource sharing) which only allows requests from the specified servers
 ## [br]
-## [br][param allowed_origins] - The origins that area allowed to be access from this sesrver
-## [br][param access_control_allowed_methods] - The methods that are allowed to be sent
+## [br][param allowed_origins] - The origins that are allowed to be accessed from this server
+## [br][param access_control_allowed_methods] - The methods that are allowed to be used
 ## [br][param access_control_allowed_headers] - The headers that are allowed to be sent
 func enable_cors(allowed_origins: PackedStringArray, access_control_allowed_methods : String = "POST, GET, OPTIONS", access_control_allowed_headers : String = "content-type"):
 	_allowed_origins = allowed_origins

--- a/example/scripts/godot_http_server_example.gd
+++ b/example/scripts/godot_http_server_example.gd
@@ -5,7 +5,7 @@ extends Node
 func _ready() -> void:
 	var server = HttpServer.new()
 	server.register_router("/", MyExampleRouter.new())
-	add_child(server)	
+	add_child(server)
 	server.enable_cors(["http://localhost:8060"])
 	server.start()
 

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 run/main_scene="res://example/scripts/http_server.tscn"
-config/features=PackedStringArray("4.0")
+config/features=PackedStringArray("4.3")
 
 [editor_plugins]
 

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 run/main_scene="res://example/scripts/http_server.tscn"
-config/features=PackedStringArray("4.3")
+config/features=PackedStringArray("4.0")
 
 [editor_plugins]
 


### PR DESCRIPTION
Changed comments to allow for viewing the documentation in godot on all main functions at least.
Functions beginning with `_` comments were kept the same.

All functions that were changed kept most of the documentation although expanded in some cases. (Fell free to revert this). Main cases being the `HttpRouter` class and `HttpServer.enable_cors()`

Please at least check my documentation for `HttpServer.enable_cors()` as there wasn't any documentation for it and i'm not 100% sure on how it works. (Although it just felt wrong to have no documentation so i included something)